### PR TITLE
Fixes broken intraday issuance: Proposal #1 

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -348,15 +348,15 @@ contract Vault is Ownable2Step, IVault {
         );
     }
 
-    /// @notice Checks that the vault is in a valid state
+    /// @notice Checks that the vault is in a valid state for issuer
     /// @notice i.e. we can wind down to 0 safely
     /// @notice reverts if the check fails
     function issuanceInvariantCheck() public view {
         _invariantCheck(indexToken.totalSupply());
     }
 
-    /// @notice Checks that the vault is in a valid state
-    /// @notice i.e. we can wind down to 0 safely
+    /// @notice Checks that the vault is in a valid state for rebalancer
+    /// @notice i.e. we maintain the index value regardless of dT
     /// @notice reverts if the check fails
     function rebalancerInvariantCheck() public view {
         (, , , uint256 currentMultiplier) = multiplier();
@@ -376,12 +376,6 @@ contract Vault is Ownable2Step, IVault {
         TokenInfo[] memory tokens = realUnits();
 
         (, , , uint256 currentMultiplier) = multiplier();
-
-        // adjust total supply by inverse of intraday fee (inflation)
-        uint256 totalSupply = fmul(
-            fdiv(lastKnownMultiplier, currentMultiplier),
-            indexToken.totalSupply()
-        );
 
         for (uint256 i; i < tokens.length; ) {
             uint256 expectedAmount = fmul(tokens[i].units, totalSupply);

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -55,7 +55,9 @@ interface IVault {
 
     function realUnits() external view returns (TokenInfo[] memory);
 
-    function invariantCheck() external view;
+    function issuanceInvariantCheck() external view;
+
+    function rebalancerInvariantCheck() external view;
 
     function isUnderlying(address target) external view returns (bool);
 

--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -65,7 +65,7 @@ contract InvokeableBounty {
 
     modifier invariantCheck() {
         _;
-        vault.invariantCheck();
+        vault.rebalancerInvariantCheck();
     }
 
     constructor(

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -20,7 +20,7 @@ contract Issuance {
 
     modifier invariantCheck() {
         _;
-        vault.invariantCheck();
+        vault.issuanceInvariantCheck();
     }
 
     modifier ReentrancyGuard() {

--- a/contracts/test/core/invoke/Bounty.t.sol
+++ b/contracts/test/core/invoke/Bounty.t.sol
@@ -79,6 +79,37 @@ contract BountyTest is StatefulTest {
     //     });
     // }
 
+    function testRebalance() public {
+        uint256 oneDayMark = block.timestamp + 1 days;
+        TokenInfo[] memory tokens = seedInitial(15);
+        TokenInfo[] memory newTokens = tokens;
+
+        for (uint256 i = 0; i < newTokens.length; i++) {
+            newTokens[i].units = (newTokens[i].units + 1);
+            IERC20(address(tokens[i].token)).approve(
+                address(bounty),
+                type(uint256).max
+            );
+            MockMintableToken(address(tokens[i].token)).mint(
+                address(this),
+                100e18
+            );
+        }
+
+        Bounty memory _bounty = Bounty({
+            infos: newTokens,
+            salt: keccak256("test"),
+            deadline: block.timestamp + 2 days
+        });
+
+        bytes32 _hash = bounty.hashBounty(_bounty);
+
+        vm.prank(authority);
+        activeBounty.setHash(_hash);
+        vm.warp(oneDayMark - 1);
+        bounty.fulfillBounty(_bounty, true);
+    }
+
     function testRemoveToken() public {
         TokenInfo[] memory tokens = seedInitial(5);
 


### PR DESCRIPTION
Previous `invariantCheck` was too strict for issuance. Unminted supply check only needs to be applied on `fulfillBounty`. 