### PR TITLE
Fixes broken intraday issuance: Proposal #2 

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -356,7 +356,7 @@ contract Vault is Ownable2Step, IVault {
 
         // adjust total supply by inverse of intraday fee (inflation)
         uint256 totalSupply = fmul(
-            unmintedInflationMultiplier(),
+            intradayMultiplier(),
             indexToken.totalSupply()
         );
 
@@ -374,7 +374,7 @@ contract Vault is Ownable2Step, IVault {
     }
 
     /// @notice Calculates the multiplier to be applied to the total supply to account for inflation
-    function unmintedInflationMultiplier() public view returns (uint256) {
+    function intradayMultiplier() public view returns (uint256) {
         (, , , uint256 currentMultiplier) = multiplier();
         uint256 multiplierToReturn = fdiv(
             lastKnownMultiplier,

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -356,7 +356,7 @@ contract Vault is Ownable2Step, IVault {
 
         // adjust total supply by inverse of intraday fee (inflation)
         uint256 totalSupply = fmul(
-            intradayMultiplier(),
+            intradayInflation(),
             indexToken.totalSupply()
         );
 
@@ -373,19 +373,16 @@ contract Vault is Ownable2Step, IVault {
         }
     }
 
-    /// @notice Calculates the multiplier to be applied to the total supply to account for inflation
-    function intradayMultiplier() public view returns (uint256) {
+    /// @notice Calculates the intraday inflation
+    function intradayInflation() public view returns (uint256) {
         (, , , uint256 currentMultiplier) = multiplier();
-        uint256 multiplierToReturn = fdiv(
-            lastKnownMultiplier,
-            currentMultiplier
-        );
+        uint256 inflation = fdiv(lastKnownMultiplier, currentMultiplier);
 
         // multiplier should never be less than 1
-        if (multiplierToReturn < SCALAR) {
+        if (inflation < SCALAR) {
             revert VaultInvariant();
         }
-        return multiplierToReturn;
+        return inflation;
     }
 
     ///////////////////////// INTERNAL /////////////////////////

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -373,9 +373,19 @@ contract Vault is Ownable2Step, IVault {
         }
     }
 
+    /// @notice Calculates the multiplier to be applied to the total supply to account for inflation
     function unmintedInflationMultiplier() public view returns (uint256) {
         (, , , uint256 currentMultiplier) = multiplier();
-        return fdiv(lastKnownMultiplier, currentMultiplier);
+        uint256 multiplierToReturn = fdiv(
+            lastKnownMultiplier,
+            currentMultiplier
+        );
+
+        // multiplier should never be less than 1
+        if (multiplierToReturn < SCALAR) {
+            revert VaultInvariant();
+        }
+        return multiplierToReturn;
     }
 
     ///////////////////////// INTERNAL /////////////////////////

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -348,17 +348,12 @@ contract Vault is Ownable2Step, IVault {
         );
     }
 
-    /// @notice Checks that the vault is in a valid state for issuer
+    /// @notice Checks that the vault is in a valid state
     /// @notice i.e. we can wind down to 0 safely
     /// @notice reverts if the check fails
-    function issuanceInvariantCheck() public view {
-        _invariantCheck(indexToken.totalSupply());
-    }
+    function invariantCheck() public view {
+        TokenInfo[] memory tokens = realUnits();
 
-    /// @notice Checks that the vault is in a valid state for rebalancer
-    /// @notice i.e. we maintain the index value regardless of dT
-    /// @notice reverts if the check fails
-    function rebalancerInvariantCheck() public view {
         (, , , uint256 currentMultiplier) = multiplier();
 
         // adjust total supply by inverse of intraday fee (inflation)
@@ -366,16 +361,6 @@ contract Vault is Ownable2Step, IVault {
             fdiv(lastKnownMultiplier, currentMultiplier),
             indexToken.totalSupply()
         );
-
-        _invariantCheck(totalSupply);
-    }
-
-    ///////////////////////// INTERNAL /////////////////////////
-
-    function _invariantCheck(uint256 totalSupply) internal view {
-        TokenInfo[] memory tokens = realUnits();
-
-        (, , , uint256 currentMultiplier) = multiplier();
 
         for (uint256 i; i < tokens.length; ) {
             uint256 expectedAmount = fmul(tokens[i].units, totalSupply);
@@ -389,6 +374,8 @@ contract Vault is Ownable2Step, IVault {
             }
         }
     }
+
+    ///////////////////////// INTERNAL /////////////////////////
 
     function _setNominal(SetNominalArgs memory args) internal {
         address token = args.token;

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -354,11 +354,9 @@ contract Vault is Ownable2Step, IVault {
     function invariantCheck() public view {
         TokenInfo[] memory tokens = realUnits();
 
-        (, , , uint256 currentMultiplier) = multiplier();
-
         // adjust total supply by inverse of intraday fee (inflation)
         uint256 totalSupply = fmul(
-            fdiv(lastKnownMultiplier, currentMultiplier),
+            unmintedInflationMultiplier(),
             indexToken.totalSupply()
         );
 
@@ -373,6 +371,11 @@ contract Vault is Ownable2Step, IVault {
                 ++i;
             }
         }
+    }
+
+    function unmintedInflationMultiplier() public view returns (uint256) {
+        (, , , uint256 currentMultiplier) = multiplier();
+        return fdiv(lastKnownMultiplier, currentMultiplier);
     }
 
     ///////////////////////// INTERNAL /////////////////////////

--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -348,15 +348,15 @@ contract Vault is Ownable2Step, IVault {
         );
     }
 
-    /// @notice Checks that the vault is in a valid state
+    /// @notice Checks that the vault is in a valid state for issuer
     /// @notice i.e. we can wind down to 0 safely
     /// @notice reverts if the check fails
     function issuanceInvariantCheck() public view {
         _invariantCheck(indexToken.totalSupply());
     }
 
-    /// @notice Checks that the vault is in a valid state
-    /// @notice i.e. we can wind down to 0 safely
+    /// @notice Checks that the vault is in a valid state for rebalancer
+    /// @notice i.e. we maintain the index value regardless of dT
     /// @notice reverts if the check fails
     function rebalancerInvariantCheck() public view {
         (, , , uint256 currentMultiplier) = multiplier();
@@ -376,12 +376,6 @@ contract Vault is Ownable2Step, IVault {
         TokenInfo[] memory tokens = realUnits();
 
         (, , , uint256 currentMultiplier) = multiplier();
-
-        // adjust total supply by inverse of intraday fee (inflation)
-        uint256 totalSupply = fmul(
-            fdiv(lastKnownMultiplier, currentMultiplier),
-            indexToken.totalSupply()
-        );
 
         for (uint256 i; i < tokens.length; ) {
             uint256 expectedAmount = fmul(tokens[i].units, totalSupply);

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -55,9 +55,7 @@ interface IVault {
 
     function realUnits() external view returns (TokenInfo[] memory);
 
-    function issuanceInvariantCheck() external view;
-
-    function rebalancerInvariantCheck() external view;
+    function invariantCheck() external view;
 
     function isUnderlying(address target) external view returns (bool);
 

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -57,6 +57,8 @@ interface IVault {
 
     function invariantCheck() external view;
 
+    function unmintedInflationMultiplier() external view returns (uint256);
+
     function isUnderlying(address target) external view returns (bool);
 
     function underlying() external view returns (address[] memory);

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -57,7 +57,7 @@ interface IVault {
 
     function invariantCheck() external view;
 
-    function unmintedInflationMultiplier() external view returns (uint256);
+    function intradayMultiplier() external view returns (uint256);
 
     function isUnderlying(address target) external view returns (bool);
 

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -57,7 +57,7 @@ interface IVault {
 
     function invariantCheck() external view;
 
-    function intradayMultiplier() external view returns (uint256);
+    function intradayInflation() external view returns (uint256);
 
     function isUnderlying(address target) external view returns (bool);
 

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -55,7 +55,9 @@ interface IVault {
 
     function realUnits() external view returns (TokenInfo[] memory);
 
-    function invariantCheck() external view;
+    function issuanceInvariantCheck() external view;
+
+    function rebalancerInvariantCheck() external view;
 
     function isUnderlying(address target) external view returns (bool);
 

--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -65,7 +65,7 @@ contract InvokeableBounty {
 
     modifier invariantCheck() {
         _;
-        vault.rebalancerInvariantCheck();
+        vault.invariantCheck();
     }
 
     constructor(

--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -65,7 +65,7 @@ contract InvokeableBounty {
 
     modifier invariantCheck() {
         _;
-        vault.invariantCheck();
+        vault.rebalancerInvariantCheck();
     }
 
     constructor(

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -44,13 +44,12 @@ contract Issuance {
 
         require(tokens.length > 0, "No tokens in vault");
 
-        uint256 intradayMultiplier = vault.intradayMultiplier();
+        uint256 amountIncludingIntradayInflation = fmul(
+            vault.intradayMultiplier(),
+            amount
+        );
 
         for (uint256 i; i < tokens.length; ) {
-            uint256 amountIncludingIntradayInflation = fmul(
-                intradayMultiplier,
-                amount
-            );
             uint256 underlyingAmount = fmul(
                 tokens[i].units,
                 amountIncludingIntradayInflation
@@ -84,8 +83,16 @@ contract Issuance {
             tokens.length
         );
 
+        uint256 amountIncludingIntradayInflation = fmul(
+            vault.intradayMultiplier(),
+            amount
+        );
+
         for (uint256 i; i < tokens.length; ) {
-            uint256 underlyingAmount = fmul(tokens[i].units, amount);
+            uint256 underlyingAmount = fmul(
+                tokens[i].units,
+                amountIncludingIntradayInflation
+            );
 
             args[i] = IVault.InvokeERC20Args({
                 token: tokens[i].token,

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -20,7 +20,7 @@ contract Issuance {
 
     modifier invariantCheck() {
         _;
-        vault.invariantCheck();
+        vault.issuanceInvariantCheck();
     }
 
     modifier ReentrancyGuard() {

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -44,17 +44,16 @@ contract Issuance {
 
         require(tokens.length > 0, "No tokens in vault");
 
-        uint256 unmintedInflationMultiplier = vault
-            .unmintedInflationMultiplier();
+        uint256 intradayMultiplier = vault.intradayMultiplier();
 
         for (uint256 i; i < tokens.length; ) {
-            uint256 amountIncludingInflation = fmul(
-                unmintedInflationMultiplier,
+            uint256 amountIncludingIntradayInflation = fmul(
+                intradayMultiplier,
                 amount
             );
             uint256 underlyingAmount = fmul(
                 tokens[i].units,
-                amountIncludingInflation
+                amountIncludingIntradayInflation
             ) + 1;
 
             IERC20(tokens[i].token).safeTransferFrom(

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -45,7 +45,7 @@ contract Issuance {
         require(tokens.length > 0, "No tokens in vault");
 
         uint256 amountIncludingIntradayInflation = fmul(
-            vault.intradayMultiplier(),
+            vault.intradayInflation(),
             amount
         );
 

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -20,7 +20,7 @@ contract Issuance {
 
     modifier invariantCheck() {
         _;
-        vault.issuanceInvariantCheck();
+        vault.invariantCheck();
     }
 
     modifier ReentrancyGuard() {

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -44,9 +44,12 @@ contract Issuance {
 
         require(tokens.length > 0, "No tokens in vault");
 
+        uint256 unmintedInflationMultiplier = vault
+            .unmintedInflationMultiplier();
+
         for (uint256 i; i < tokens.length; ) {
             uint256 amountIncludingInflation = fmul(
-                vault.unmintedInflationMultiplier(),
+                unmintedInflationMultiplier,
                 amount
             );
             uint256 underlyingAmount = fmul(

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -40,15 +40,13 @@ contract Issuance {
     /// @dev reentrancy guard in case callback in tokens
     function issue(uint256 amount) external invariantCheck ReentrancyGuard {
         vault.tryInflation();
-        (, uint256 lastKnownMultiplier, , uint256 currentMultiplier) = vault
-            .multiplier();
         TokenInfo[] memory tokens = vault.realUnits();
 
         require(tokens.length > 0, "No tokens in vault");
 
         for (uint256 i; i < tokens.length; ) {
             uint256 amountIncludingInflation = fmul(
-                fdiv(lastKnownMultiplier, currentMultiplier),
+                vault.unmintedInflationMultiplier(),
                 amount
             );
             uint256 underlyingAmount = fmul(

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -83,16 +83,8 @@ contract Issuance {
             tokens.length
         );
 
-        uint256 amountIncludingIntradayInflation = fmul(
-            vault.intradayMultiplier(),
-            amount
-        );
-
         for (uint256 i; i < tokens.length; ) {
-            uint256 underlyingAmount = fmul(
-                tokens[i].units,
-                amountIncludingIntradayInflation
-            );
+            uint256 underlyingAmount = fmul(tokens[i].units, amount);
 
             args[i] = IVault.InvokeERC20Args({
                 token: tokens[i].token,

--- a/contracts/test/core/invoke/Bounty.t.sol
+++ b/contracts/test/core/invoke/Bounty.t.sol
@@ -79,6 +79,37 @@ contract BountyTest is StatefulTest {
     //     });
     // }
 
+    function testRebalance() public {
+        uint256 oneDayMark = block.timestamp + 1 days;
+        TokenInfo[] memory tokens = seedInitial(15);
+        TokenInfo[] memory newTokens = tokens;
+
+        for (uint256 i = 0; i < newTokens.length; i++) {
+            newTokens[i].units = (newTokens[i].units + 1);
+            IERC20(address(tokens[i].token)).approve(
+                address(bounty),
+                type(uint256).max
+            );
+            MockMintableToken(address(tokens[i].token)).mint(
+                address(this),
+                100e18
+            );
+        }
+
+        Bounty memory _bounty = Bounty({
+            infos: newTokens,
+            salt: keccak256("test"),
+            deadline: block.timestamp + 2 days
+        });
+
+        bytes32 _hash = bounty.hashBounty(_bounty);
+
+        vm.prank(authority);
+        activeBounty.setHash(_hash);
+        vm.warp(oneDayMark - 1);
+        bounty.fulfillBounty(_bounty, true);
+    }
+
     function testRemoveToken() public {
         TokenInfo[] memory tokens = seedInitial(5);
 

--- a/contracts/test/core/invoke/Issuance.t.sol
+++ b/contracts/test/core/invoke/Issuance.t.sol
@@ -7,7 +7,7 @@ import {SCALAR} from "src/lib/FixedPoint.sol";
 import {IVault} from "src/interfaces/IVault.sol";
 
 contract IssuanceTest is StatefulTest {
-    function testToZero() public {
+    function testGoToZero() public {
         seedInitial(10);
         mint(5e18);
         burn(indexToken.totalSupply());
@@ -18,7 +18,10 @@ contract IssuanceTest is StatefulTest {
         }
     }
 
-    function testToZeroWithUnmintedInflation() public {
+    function testCantGoToZeroWithUnmintedInflation() public {
+        // Q: Who keeps the intraday fee on the tokens that are being burnt? The user, vault, or the feeRecipient?
+        // A: For now, the vault keeps the intraday fee on the tokens that are being burnt.
+        // If this amount becomes meaningful, we can expose a function to withdraw it separately.
         vault.setFeeRecipient(address(this));
         seedInitial(10);
         mint(5e18);
@@ -29,11 +32,11 @@ contract IssuanceTest is StatefulTest {
         address[] memory underlying = vault.underlying();
         assertEq(indexToken.totalSupply(), 0);
         for (uint256 i; i < underlying.length; i++) {
-            assertLe(IERC20(underlying[i]).balanceOf(address(vault)), 100);
+            assertGe(IERC20(underlying[i]).balanceOf(address(vault)), 100);
         }
     }
 
-    function testToZeroWithMintedInflation() public {
+    function testGoToZeroWithMintedInflation() public {
         vault.setFeeRecipient(address(this));
         seedInitial(10);
         mint(5e18);

--- a/contracts/test/core/invoke/Issuance.t.sol
+++ b/contracts/test/core/invoke/Issuance.t.sol
@@ -29,7 +29,7 @@ contract IssuanceTest is StatefulTest {
         address[] memory underlying = vault.underlying();
         assertEq(indexToken.totalSupply(), 0);
         for (uint256 i; i < underlying.length; i++) {
-            assertGe(IERC20(underlying[i]).balanceOf(address(vault)), 100);
+            assertLe(IERC20(underlying[i]).balanceOf(address(vault)), 100);
         }
     }
 


### PR DESCRIPTION
This addresses the root issue of the problem: when issuing new tokens, Issuance does not take into fees on the newly minted tokens into account if they haven't been minted. 

Somebody has to pay to collateralize unaccrued fees on newly minted tokens upon issuance. Should it be the user, the vault, or the fee recipient? Applying the unminted token balance to invariantCheck means we are choosing the user to pay for this fee.

The same question arises for redemptions as well. Who gets paid unaccrued fees on the tokens that are being burnt? Choosing to not adjust amounts transferred upon redemption to account for unaccrued intraday fees means the fees are being paid to the vault. It is subsequently held by the vault, until it is manually excavated.

I believe this is the maximally safe choice, at the cost of more expensive issuance and inconvenience caused by having to manually excavate the fees. The vault is maximally greedy – it asks for the maximum amount possible on issuance, and it keeps the intraday fees on redemption instead of giving that to anyone else.