### PR TITLE
Fixes empty total supply checkpoints

### DIFF
--- a/contracts/src/IndexToken.sol
+++ b/contracts/src/IndexToken.sol
@@ -52,7 +52,7 @@ contract IndexToken is ERC20VotesUpgradeable, IIndexToken {
 
         _totalSupplyCheckpoints.push(
             Checkpoint({
-                fromBlock: uint32(block.number),
+                fromBlock: uint32(block.number - 1),
                 votes: uint224(totalSupply())
             })
         );

--- a/contracts/src/IndexToken.sol
+++ b/contracts/src/IndexToken.sol
@@ -45,6 +45,18 @@ contract IndexToken is ERC20VotesUpgradeable, IIndexToken {
             sstore(102, hashedVersion)
         }
 
+        Checkpoint[] storage _totalSupplyCheckpoints;
+        assembly {
+            _totalSupplyCheckpoints.slot := 206
+        }
+
+        _totalSupplyCheckpoints.push(
+            Checkpoint({
+                fromBlock: uint32(block.number),
+                votes: uint224(totalSupply())
+            })
+        );
+
         assembly {
             sstore(MINTER_SLOT, _minter)
         }


### PR DESCRIPTION
Upon upgrading, there are no checkpoints. A further consequence of this is that no user will be able to redeem their tokens, due to lack of total supply checkpoints. An underflow will occur if they attempt to redeem greater than what's stored in total supply checkpoints, which starts incrementing when new tokens are issued. 

This PR fixes the issue by overriding the storage of total supply checkpoints at point of initialization with current block and total supply of the token. 