### PR TITLE
Fixes wrongful change of proxy admin

### DIFF
--- a/contracts/src/scripts/__2__MultisigStep2.s.sol
+++ b/contracts/src/scripts/__2__MultisigStep2.s.sol
@@ -24,10 +24,7 @@ contract MultisigStep2Script is Script {
         Vault(_vault).setFeeScaled(FEE_SCALED);
         Vault(_vault).setRebalancer(_timelockInvokeableBounty);
         Vault(_vault).transferOwnership(_timelockController);
-        ProxyAdmin(PROXY_ADMIN).changeProxyAdmin(
-            ITransparentUpgradeableProxy(PROXY),
-            _timelockController
-        );
+        ProxyAdmin(PROXY_ADMIN).transferOwnership(_timelockController);
         vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
Instead of changing the proxy admin, the multisig should be transferring the ownership to the timelock instead. 