### PR TITLE
Add zero address checks

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -67,6 +67,9 @@ contract Vault is Ownable2Step, IVault {
         address _emergencyResponder,
         uint256 _feeScaled
     ) {
+        if (_owner == address(0)) revert VaultZeroCheck();
+        if (_feeRecipient == address(0)) revert VaultZeroCheck();
+        if (_emergencyResponder == address(0)) revert VaultZeroCheck();
         if (_feeScaled > SCALAR) {
             revert AMKTVaultFeeTooLarge();
         }
@@ -90,6 +93,7 @@ contract Vault is Ownable2Step, IVault {
     /// @param _issuance The issuance module address
     /// @dev only owner
     function setIssuance(address _issuance) external only(owner()) {
+        if (_issuance == address(0)) revert VaultZeroCheck();
         issuance = _issuance;
         emit VaultIssuanceSet(_issuance);
     }
@@ -98,6 +102,7 @@ contract Vault is Ownable2Step, IVault {
     /// @param _rebalancer The rebalancer module address
     /// @dev only owner
     function setRebalancer(address _rebalancer) external only(owner()) {
+        if (_rebalancer == address(0)) revert VaultZeroCheck();
         rebalancer = _rebalancer;
         emit VaultRebalancerSet(_rebalancer);
     }
@@ -106,6 +111,7 @@ contract Vault is Ownable2Step, IVault {
     /// @param _feeRecipient The fee recipient address
     /// @dev only owner
     function setFeeRecipient(address _feeRecipient) external only(owner()) {
+        if (_feeRecipient == address(0)) revert VaultZeroCheck();
         feeRecipient = _feeRecipient;
         emit VaultFeeRecipientSet(_feeRecipient);
     }
@@ -116,6 +122,7 @@ contract Vault is Ownable2Step, IVault {
     function setEmergencyResponder(
         address _emergencyResponder
     ) external only(owner()) {
+        if (_emergencyResponder == address(0)) revert VaultZeroCheck();
         emergencyResponder = _emergencyResponder;
         emit VaultEmergencyResponderSet(_emergencyResponder);
     }

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -9,6 +9,7 @@ interface IVault {
     error AMKTVaultFeeTooLarge();
     error AMKTVaultEmergency();
     error VaultInvariant();
+    error VaultZeroCheck();
 
     event VaultIssuanceSet(address issuance);
     event VaultRebalancerSet(address rebalancer);

--- a/contracts/src/invoke/ActiveBounty.sol
+++ b/contracts/src/invoke/ActiveBounty.sol
@@ -2,6 +2,8 @@ pragma solidity =0.8.15;
 
 contract ActiveBounty {
     error ActiveBountyAuth();
+    error ActiveBountyZeroCheck();
+
     event ActiveBountyHashSet(bytes32 bountyHash);
 
     address public immutable authority;
@@ -9,6 +11,7 @@ contract ActiveBounty {
     bytes32 public activeBounty;
 
     constructor(address _authority) {
+        if (_authority == address(0)) revert ActiveBountyZeroCheck();
         authority = _authority;
     }
 


### PR DESCRIPTION
Add zero address checks to prevent accidental loss of roles. Ability to renounce roles still remains with `address(1)`. It's a lot harder to accidentally submit 1 than it is to submit 0.  