### PR TITLE
Use encode instead of encodePacked to prevent collision

### DIFF
--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -266,7 +266,7 @@ contract InvokeableBounty {
     ) public view returns (bytes32 hash) {
         return
             keccak256(
-                abi.encodePacked(
+                abi.encode(
                     "alongside::invoker::bounty",
                     abi.encode(version),
                     abi.encode(chainId),


### PR DESCRIPTION
Since we have multiple dynamic types, use `abi.encode` instead of `abiEncodePacked` to prevent potential collision. https://github.com/crytic/slither/wiki/Detector-Documentation#abi-encodepacked-collision