### PR TITLE
Expose virtual units in `IVault.sol`

### DIFF
--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -55,6 +55,8 @@ interface IVault {
 
     function realUnits() external view returns (TokenInfo[] memory);
 
+    function virtualUnits() external view returns (TokenInfo[] memory);
+
     function invariantCheck() external view;
 
     function isUnderlying(address target) external view returns (bool);


### PR DESCRIPTION
QoL improvement for IVault consumers. We should stay consistent and expose public/external fns in the interface. 