### PR TITLE
Replace `quote` in `Issuance.sol` with a periphery `IssuanceQuoter.sol`

### DIFF
--- a/contracts/periphery/IssuanceQuoter.sol
+++ b/contracts/periphery/IssuanceQuoter.sol
@@ -1,0 +1,40 @@
+pragma solidity =0.8.18;
+import {IVault} from "src/interfaces/IVault.sol";
+import {fmul} from "src/lib/FixedPoint.sol";
+import {TokenInfo} from "src/Common.sol";
+
+contract IssuanceQuoter {
+    IVault vault;
+
+    constructor(address _vault) {
+        vault = IVault(_vault);
+    }
+
+    /// @notice Quote the amount of underlying tokens needed to issue index tokens
+    /// @param amount The amount of index tokens to issue
+    /// @return tokens The underlying tokens and amounts needed to issue index tokens
+    /// @dev does not support tryInflation() yet
+    function quoteIssue(
+        uint256 amount
+    ) external view returns (TokenInfo[] memory) {
+        TokenInfo[] memory tokens = vault.realUnits();
+
+        require(tokens.length > 0, "No tokens in vault");
+
+        uint256 amountIncludingIntradayInflation = fmul(
+            vault.intradayInflation(),
+            amount
+        ) + 1;
+
+        for (uint256 i; i < tokens.length; i++) {
+            uint256 underlyingAmount = fmul(
+                tokens[i].units + 1,
+                amountIncludingIntradayInflation
+            ) + 1;
+
+            tokens[i].units = underlyingAmount;
+        }
+
+        return tokens;
+    }
+}

--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -101,18 +101,4 @@ contract Issuance {
 
         vault.invokeERC20s(args);
     }
-
-    /// @notice Quote the amount of underlying tokens needed to issue index tokens
-    /// @param amount The amount of index tokens to issue
-    /// @return tokens The underlying tokens and amounts needed to issue index tokens
-    /// @dev subtract 1 from each unit to account for rounding if you need an exact redemption quote
-    function quote(uint256 amount) external view returns (TokenInfo[] memory) {
-        TokenInfo[] memory tokens = vault.realUnits();
-
-        for (uint256 i; i < tokens.length; i++) {
-            tokens[i].units = fmul(tokens[i].units, amount) + 1;
-        }
-
-        return tokens;
-    }
 }


### PR DESCRIPTION
If you expand into this PR, you'll notice that the underlying amounts produced by `quote` actually does not match what `issue` expects. This shows that we should avoid duplication of code if possible, to prevent a potential mismatch in the future. Further, `quote` is not essential to the core functionality of the protocol. 

Therefore, this PR suggests introducing the concept of Periphery contracts which are not subject to the intense security scrutiny of the core contracts, and to move the `quote` functionality there.  