### PR TITLE
Fix: `fmul` rounding in Bounty quote leading to broken invariant check 

### DIFF
--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -217,7 +217,7 @@ contract InvokeableBounty {
             } else if (targetUnits > virtualUnits) {
                 ins[lenIns] = TokenInfo(
                     token,
-                    fmul(targetUnits - virtualUnits, input.supply)
+                    fmul(targetUnits - virtualUnits + 1, input.supply) + 1
                 );
 
                 unchecked {

--- a/contracts/test/core/State.t.sol
+++ b/contracts/test/core/State.t.sol
@@ -126,7 +126,7 @@ library Mocks {
 
             uint256 amount = (1 + i) * 1e18;
 
-            IERC20(addr).approve(address(approve), amount);
+            IERC20(addr).approve(address(approve), amount + 2); // add 2 to account for fulfillBounty rounding
 
             tokens[i] = TokenInfo({token: addr, units: amount});
         }

--- a/contracts/test/core/invoke/Bounty.t.sol
+++ b/contracts/test/core/invoke/Bounty.t.sol
@@ -29,7 +29,7 @@ contract BountyTest is StatefulTest {
             // assert the proper balance is included
             assertEq(
                 IERC20(address(token)).balanceOf(address(vault)),
-                (i + 1) * SCALAR
+                (i + 1) * SCALAR + 2
             );
 
             // assert the token was marked as underlying
@@ -105,7 +105,7 @@ contract BountyTest is StatefulTest {
 
         assertEq(vault.isUnderlying(newTokensNominals[0].token), false);
         assertEq(
-            IERC20(address(tokens[0].token)).balanceOf(address(vault)) <= 1,
+            IERC20(address(tokens[0].token)).balanceOf(address(vault)) <= 2,
             true
         );
     }

--- a/contracts/test/upgrade/UpgradedBounty.t.sol
+++ b/contracts/test/upgrade/UpgradedBounty.t.sol
@@ -1,0 +1,114 @@
+pragma solidity =0.8.18;
+
+import {UpgradeTest} from "./helpers/Upgrade.t.sol";
+import {Dealer} from "test/Dealer.t.sol";
+import {TokenInfo} from "src/Common.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {InvokeableBounty, Bounty} from "src/invoke/Bounty.sol";
+import {MockMintableToken} from "mocks/MockMintableToken.sol";
+import {MULTISIG} from "src/scripts/Config.sol";
+import {fmul} from "src/lib/FixedPoint.sol";
+import {console} from "forge-std/console.sol";
+
+contract UpgradedBountyTest is UpgradeTest {
+    function testBountyInvariant(uint256 numTokensToAdd, uint256 rand) public {
+        numTokensToAdd = bound(numTokensToAdd, 0, 25);
+        TokenInfo[] memory oldUnits = vault.virtualUnits();
+        Bounty memory bounty = generateValidBounty(numTokensToAdd, rand);
+        TokenInfo[] memory proposedUnits = bounty.infos;
+        bytes32 _hash = timelockInvokeableBounty.hashBounty(bounty);
+        vm.prank(address(timelockController));
+        timelockActiveBounty.setHash(_hash);
+        satisfyFulfillerBalances(address(this), bounty);
+        timelockInvokeableBounty.fulfillBounty(bounty, false);
+        // INVARIANT 1: proposed units are the same as fulfilled units
+        TokenInfo[] memory fulfilledUnits = vault.virtualUnits();
+        uint256 skipCounter = 0;
+        for (uint256 i = 0; i < proposedUnits.length; i++) {
+            if (proposedUnits[i].units == 0) {
+                skipCounter += 1;
+                assertEq(vault.isUnderlying(proposedUnits[i].token), false);
+            } else {
+                assertEq(
+                    fulfilledUnits[i - skipCounter].units,
+                    proposedUnits[i].units
+                );
+            }
+        }
+    }
+
+    function satisfyFulfillerBalances(
+        address fulfiller,
+        Bounty memory bounty
+    ) internal {
+        Dealer dealer = new Dealer();
+        TokenInfo[] memory units = bounty.infos;
+        for (uint256 i = 0; i < units.length; i++) {
+            if (units[i].units == 0) {
+                continue;
+            }
+            IERC20(units[i].token).approve(
+                address(timelockInvokeableBounty),
+                type(uint256).max
+            );
+            dealer.dealToken(units[i].token, fulfiller, type(uint256).max / 10); // a very large number, but wouldn't overflow with existing supply
+        }
+    }
+
+    function generateValidBounty(
+        uint256 numTokensToAdd,
+        uint256 rand
+    ) internal returns (Bounty memory) {
+        TokenInfo[] memory currentUnits = vault.virtualUnits();
+        TokenInfo[] memory newUnits = new TokenInfo[](
+            currentUnits.length + numTokensToAdd
+        );
+        // randomize old tokens
+        for (uint256 i = 0; i < currentUnits.length; i++) {
+            if (rand % 10 == 0) {
+                newUnits[i] = TokenInfo({
+                    token: currentUnits[i].token,
+                    units: 0
+                });
+            } else if (rand % 2 == 0) {
+                newUnits[i] = TokenInfo({
+                    token: currentUnits[i].token,
+                    units: currentUnits[i].units +
+                        (rand % currentUnits[i].units)
+                });
+            } else {
+                // this can also result in 0 units
+                newUnits[i] = TokenInfo({
+                    token: currentUnits[i].token,
+                    units: currentUnits[i].units -
+                        (rand % currentUnits[i].units)
+                });
+            }
+        }
+        // add new tokens
+        for (uint256 i = currentUnits.length; i < newUnits.length; i++) {
+            newUnits[i] = TokenInfo({
+                token: address(new MockMintableToken("test", "test", 18, 0)),
+                units: rand % 1e18
+            });
+        }
+
+        Bounty memory bounty = Bounty({
+            infos: newUnits,
+            fulfiller: address(this),
+            salt: keccak256("test"),
+            deadline: block.timestamp + 1000
+        });
+
+        // loop through infos and log them all
+        for (uint256 i = 0; i < bounty.infos.length; i++) {
+            console.log(
+                "token: %s, units: %s",
+                bounty.infos[i].token,
+                bounty.infos[i].units
+            );
+        }
+
+        return bounty;
+    }
+}

--- a/contracts/test/upgrade/UpgradedState.t.sol
+++ b/contracts/test/upgrade/UpgradedState.t.sol
@@ -224,7 +224,7 @@ contract UpgradedStateTest is UpgradeTest {
             IERC20 token = IERC20(underlying[i]);
             assertEq(
                 token.balanceOf(address(vault)),
-                fmul(tokens[i].units, AMKT.totalSupply())
+                fmul(tokens[i].units + 1, AMKT.totalSupply()) + 1
             );
         }
     }

--- a/contracts/test/upgrade/helpers/Upgrade.t.sol
+++ b/contracts/test/upgrade/helpers/Upgrade.t.sol
@@ -85,7 +85,7 @@ contract UpgradeTest is GnosisTest {
             dealer.dealToken(
                 tokens[i].token,
                 MULTISIG,
-                fmul(tokens[i].units, AMKT.totalSupply())
+                fmul(tokens[i].units + 1, AMKT.totalSupply()) + 1
             );
         }
     }
@@ -97,7 +97,7 @@ contract UpgradeTest is GnosisTest {
             IERC20 token = IERC20(tokens[i].token);
             assertEq(
                 token.balanceOf(MULTISIG),
-                fmul(tokens[i].units, AMKT.totalSupply())
+                fmul(tokens[i].units + 1, AMKT.totalSupply()) + 1
             );
         }
     }


### PR DESCRIPTION
Similar to #12, fulfilling a bounty can run into an invariant check revert under certain circumstances, due to the fact Bounty uses a diff of the units * supply to calculate ins/outs, whereas the invariant check uses units * supply to calculate invariant. This means there could be a rounding down that exists in bounty quote that doesn't exist in invariant, and vice versa. 

In #12, the difference in token supply causes the mismatch. This time, the difference in units causes the mismatch.

Without the fix: <img width="633" alt="Screen Shot 2023-10-05 at 6 09 36 PM" src="https://github.com/Alongside-Finance/amkt-v2/assets/12927159/d66123ba-0f21-4a03-ab61-fae222d80ee7"> 

 