### PR TITLE
Feature: Only allow multisig to execute proposals 

### DIFF
--- a/contracts/src/scripts/CoreDeploy.s.sol
+++ b/contracts/src/scripts/CoreDeploy.s.sol
@@ -47,7 +47,7 @@ contract CoreDeployScript is Script {
 
         deployed.timelockController.grantRole(
             deployed.timelockController.EXECUTOR_ROLE(),
-            address(0)
+            MULTISIG
         );
         deployed.timelockController.grantRole(
             deployed.timelockController.PROPOSER_ROLE(),

--- a/contracts/test/upgrade/UpgradedGovernance.t.sol
+++ b/contracts/test/upgrade/UpgradedGovernance.t.sol
@@ -229,18 +229,23 @@ contract UpgradedGovernanceTest is UpgradeTest {
             proposal.calldatas,
             proposal.descriptionHash
         );
+        vm.stopPrank();
+
+        vm.startPrank(MULTISIG);
         vm.expectRevert();
-        governor.execute(
+        timelockController.executeBatch(
             proposal.targets,
             proposal.values,
             proposal.calldatas,
+            0,
             proposal.descriptionHash
         );
         _warpForward(CANCELLATION_PERIOD);
-        governor.execute(
+        timelockController.executeBatch(
             proposal.targets,
             proposal.values,
             proposal.calldatas,
+            0,
             proposal.descriptionHash
         );
 

--- a/contracts/test/upgrade/UpgradedState.t.sol
+++ b/contracts/test/upgrade/UpgradedState.t.sol
@@ -54,7 +54,7 @@ contract UpgradedStateTest is UpgradeTest {
         assertEq(
             timelockController.hasRole(
                 timelockController.EXECUTOR_ROLE(),
-                address(0)
+                MULTISIG
             ),
             true
         );


### PR DESCRIPTION
In order to prevent the protocol being vulnerable to governance takeover + spam attacks and lack of attention by the canceller, we propose that the emergency multisig solely be given the role of the timelock executor. 

This causes an additional complexity: as of v4.8.0, OpenZeppelin's Governor explicitly prevents `onlyGovernance` actions from being called by anything except the Governor itself, as part of `execute`. However, `execute` will revert since `GovernorTimelockControl` extension calls `executeBatch` directly on `TimelockController`, which it does not have permissions to do anymore. 

The reason for the above prevention is as follows (from docs in `GovernorTimelockControl`): 
```
 * WARNING: Setting up the TimelockController to have additional proposers besides the governor is very risky, as it
 * grants them powers that they must be trusted or known not to use: 1) {onlyGovernance} functions like {relay} are
 * available to them through the timelock, and 2) approved governance proposals can be blocked by them, effectively
 * executing a Denial of Service attack. This risk will be mitigated in a future release.
 ```

Given that in our system, the multisig has Proposer, Canceller, and Executor roles, the case above warns about is exactly what we wish for for the time being. At the same time, we do not know what Governance will look like in the future, and the trust assumptions may need to evolve over time. 

Thus, we propose keeping the Governor implementation complexity to minimum by simply changing the executor role address to the multisig address, and showcase a way the multisig can effectively bypass the `onlyGovernance` check preventing our desired action by "sandwiching" the `onlyGovernance` proposal execution with granting and revoking the `EXECUTOR` role to the governor. As `TimelockConrtoller` is still the only entity that can execute timelock proposals, it will be able to ensure that it is executed atomically.     
