### PR TITLE
Fix: Bounty stack too deep

### DIFF
--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -161,7 +161,6 @@ contract InvokeableBounty is IInvokeableBounty {
         // store the lengths because we don't actually know the size off the bat
         uint256 lenOuts;
         uint256 lenIns;
-        uint256 lenNominals;
 
         for (uint256 i; i < input.targets.length; i++) {
             address token = input.targets[i].token;
@@ -197,12 +196,13 @@ contract InvokeableBounty is IInvokeableBounty {
                 continue;
             }
 
-            nominals[lenNominals] = IVault.SetNominalArgs(token, targetUnits);
-
-            unchecked {
-                lenNominals++;
-            }
+            nominals[lenOuts + lenIns - 1] = IVault.SetNominalArgs(
+                token,
+                targetUnits
+            );
         }
+
+        uint256 lenNominals = lenOuts + lenIns;
 
         // use assembly to set the actual sizes so were not sending over a bunch of empty data
         // no effect, since the compiler is planning on allocating outside of this empty zone anyway


### PR DESCRIPTION
When running `forge coverage`, `_quote` in `fulfillBounty` unfortunately runs into a stack too deep error. This does not happen when running `forge test`, however. 

This PR uses the fact that lenNominals can actually be derived from lenOuts and lenIns, removing the need to track lenNominals in a separate variable. 

