### PR TITLE
Fix: Remove unused invoke

### DIFF
--- a/contracts/src/Vault.sol
+++ b/contracts/src/Vault.sol
@@ -188,15 +188,6 @@ contract Vault is Ownable2Step, IVault {
         }
     }
 
-    /// @notice Set the nominal units of a token
-    /// @param args The SetNominalArgs
-    /// @dev only rebalancer
-    function invokeSetNominal(
-        SetNominalArgs calldata args
-    ) external whenNotEmergency only(rebalancer) {
-        _setNominal(args);
-    }
-
     ///////////////////////// ISSUANCE /////////////////////////
 
     /// @notice Mint index tokens
@@ -232,13 +223,6 @@ contract Vault is Ownable2Step, IVault {
 
             _invokeERC20(arg.token, arg.to, arg.amount);
         }
-    }
-
-    /// @notice Invoke ERC20 transfer
-    /// @param args The InvokeERC20Args
-    /// @dev only invokers
-    function invokeERC20(InvokeERC20Args calldata args) external onlyInvokers {
-        _invokeERC20(args.token, args.to, args.amount);
     }
 
     ///////////////////////// VIEW ////////////////////////

--- a/contracts/src/interfaces/IVault.sol
+++ b/contracts/src/interfaces/IVault.sol
@@ -48,10 +48,6 @@ interface IVault {
 
     function invokeSetNominals(SetNominalArgs[] calldata args) external;
 
-    function invokeERC20(InvokeERC20Args calldata args) external;
-
-    function invokeSetNominal(SetNominalArgs calldata args) external;
-
     function virtualUnits(address token) external view returns (uint256);
 
     function virtualUnits() external view returns (TokenInfo[] memory);

--- a/contracts/test/core/Vault.t.sol
+++ b/contracts/test/core/Vault.t.sol
@@ -106,7 +106,9 @@ contract VaultTest is StatefulTest {
 
     function rebalancerFunctions(bool toFail) public {
         if (toFail) vm.expectRevert();
-        vault.invokeSetNominal(IVault.SetNominalArgs(address(0), 1));
+        IVault.SetNominalArgs[] memory args = new IVault.SetNominalArgs[](1);
+        args[0] = IVault.SetNominalArgs(address(0), 1);
+        vault.invokeSetNominals(args);
         // TODO: set nominals
     }
 
@@ -121,7 +123,9 @@ contract VaultTest is StatefulTest {
         address[] memory tokens = vault.underlying();
 
         if (toFail) vm.expectRevert();
-        vault.invokeERC20(IVault.InvokeERC20Args(tokens[0], address(0), 0));
+        IVault.InvokeERC20Args[] memory args = new IVault.InvokeERC20Args[](1);
+        args[0] = IVault.InvokeERC20Args(tokens[0], address(0), 0);
+        vault.invokeERC20s(args);
     }
 
     function ownerFunctions(bool toFail) public {

--- a/contracts/test/core/invoke/Issuance.t.sol
+++ b/contracts/test/core/invoke/Issuance.t.sol
@@ -21,13 +21,13 @@ contract IssuanceTest is StatefulTest {
             address(vault)
         );
         uint256 amountToRemove = currentBalance - requiredBalance + 3; // 3 is added because 2 is added via issue
-        vault.invokeERC20(
-            IVault.InvokeERC20Args(
-                virtualUnits[0].token,
-                address(1),
-                amountToRemove
-            )
+        IVault.InvokeERC20Args[] memory args = new IVault.InvokeERC20Args[](1);
+        args[0] = IVault.InvokeERC20Args(
+            virtualUnits[0].token,
+            address(1),
+            amountToRemove
         );
+        vault.invokeERC20s(args);
         vault.setIssuance(address(issuance));
 
         uint256 amount = 1e18;


### PR DESCRIPTION
Removes `invokeSetNominal` and `invokeERC20` which are currently redundant and not actually used. `invokeSetNominals` and `invokeERC20s` are sufficient.