### PR TITLE
Redeeming AMKT does not require approvals

### DIFF
--- a/contracts/src/invoke/Issuance.sol
+++ b/contracts/src/invoke/Issuance.sol
@@ -62,7 +62,6 @@ contract Issuance is IIssuance {
 
     /// @notice Redeem index tokens
     /// @param amount The amount of index tokens to redeem
-    /// @dev requies approval of index token
     /// @dev reentrancy guard in case callback in tokens
     function redeem(uint256 amount) external invariantCheck reentrancyGuard {
         TokenInfo[] memory tokens = vault.virtualUnits();

--- a/contracts/test/core/State.t.sol
+++ b/contracts/test/core/State.t.sol
@@ -97,7 +97,6 @@ contract StatefulTest is BaseTest, IRebalancer {
     }
 
     function burn(uint256 amount) internal {
-        indexToken.approve(address(issuance), amount);
         issuance.redeem(amount);
     }
 

--- a/contracts/test/invariant/IssuanceInvariant.t.sol
+++ b/contracts/test/invariant/IssuanceInvariant.t.sol
@@ -54,7 +54,6 @@ contract IssuanceInvariantTest is StatefulTest {
             );
         }
 
-        // indexToken.approve(address(issuance), redeemAmount);
         issuance.redeem(redeemAmount);
 
         uint256[] memory endingRedemptionVaultBalances = new uint256[](

--- a/contracts/test/invariant/IssuanceInvariant.t.sol
+++ b/contracts/test/invariant/IssuanceInvariant.t.sol
@@ -54,7 +54,7 @@ contract IssuanceInvariantTest is StatefulTest {
             );
         }
 
-        indexToken.approve(address(issuance), redeemAmount);
+        // indexToken.approve(address(issuance), redeemAmount);
         issuance.redeem(redeemAmount);
 
         uint256[] memory endingRedemptionVaultBalances = new uint256[](

--- a/contracts/test/symbolic/SymbolicState.t.sol
+++ b/contracts/test/symbolic/SymbolicState.t.sol
@@ -95,7 +95,6 @@ contract SymbolicStatefulTest is SymTest, BaseTest {
     }
 
     function burn(uint256 amount) internal {
-        indexToken.approve(address(issuance), amount);
         issuance.redeem(amount);
     }
 

--- a/contracts/test/upgrade/UpgradedIssuance.t.sol
+++ b/contracts/test/upgrade/UpgradedIssuance.t.sol
@@ -134,9 +134,6 @@ contract UpgradedIssuanceTest is UpgradedTest {
         vm.assume(jitter < MAX_JITTER);
         vm.assume(amount <= AMKT.balanceOf(largeAmktHolder));
         feeRecipientTryInflation();
-        vm.startPrank(largeAmktHolder);
-        AMKT.approve(address(issuance), AMKT.balanceOf(largeAmktHolder));
-        vm.stopPrank();
         _warpForward(jitter);
         feeRecipientTryInflation();
         vm.prank(largeAmktHolder);


### PR DESCRIPTION
Change tests to reflect that redeeming AMKT does not require approval of the index token to Issuance. 