### PR TITLE
audit-fix Add additional gap in `IndexToken`

### DIFF
--- a/contracts/src/IndexToken.sol
+++ b/contracts/src/IndexToken.sol
@@ -18,6 +18,9 @@ contract IndexToken is ERC20VotesUpgradeable, IIndexToken {
     bytes32 public constant MINTER_SLOT =
         0x1af730152eea9813c49583a406e8dd55a4df08cae9e33ae45721374fdde82bae;
 
+    /// @dev Make sure storage slots used in previous versions are not reused
+    uint256[6] private __gap;
+
     ///=============================================================================================
     /// Modifiers
     ///=============================================================================================

--- a/contracts/test/upgrade/UpgradedStorage.t.sol
+++ b/contracts/test/upgrade/UpgradedStorage.t.sol
@@ -60,6 +60,7 @@ import {fmul} from "src/lib/FixedPoint.sol";
 // | _checkpoints                     | mapping(address => struct ERC20VotesUpgradeable.Checkpoint[]) | 205  | 0      | 32    |
 // | _totalSupplyCheckpoints          | struct ERC20VotesUpgradeable.Checkpoint[]                     | 206  | 0      | 32    |
 // | __gap                            | uint256[47]                                                   | 207  | 0      | 1504  |                                                                        |
+// | __gap                            | uint256[6]                                                    | 254  | 0      | 192   |
 
 contract UpgradedStorageTest is UpgradedTest {
     function testStorageSlotUnstructured() public {
@@ -292,6 +293,9 @@ contract UpgradedStorageTest is UpgradedTest {
 
     //// SLOT 207 - 253
     // uint256[47] __gap
+
+    /// SLOT 254 - 259
+    // uint256[6] __gap
 
     function _bytes(uint256 x) internal pure returns (bytes32) {
         return bytes32(uint256(x));


### PR DESCRIPTION
To make sure storage slots used in previous versions are not reused in the future. 