### PR TITLE
audit-fix: Remove chain id and version in Bounty

### DIFF
--- a/contracts/src/invoke/Bounty.sol
+++ b/contracts/src/invoke/Bounty.sol
@@ -22,9 +22,6 @@ contract InvokeableBounty is IInvokeableBounty {
 
     IActiveBounty public immutable activeBounty;
 
-    uint256 public immutable version;
-    uint256 public immutable chainId;
-
     uint256 public reentrancyLock = 1;
 
     modifier reentrancyGuard() {
@@ -39,17 +36,10 @@ contract InvokeableBounty is IInvokeableBounty {
         vault.invariantCheck();
     }
 
-    constructor(
-        address _vault,
-        address _activeBounty,
-        uint256 _version,
-        uint256 _chainId
-    ) {
+    constructor(address _vault, address _activeBounty) {
         vault = IVault(_vault);
         indexToken = IIndexToken(vault.indexToken());
         activeBounty = IActiveBounty(_activeBounty);
-        version = _version;
-        chainId = _chainId;
     }
 
     /// @dev we send out the tokens first, so we need to check for weird supply stuff
@@ -117,8 +107,6 @@ contract InvokeableBounty is IInvokeableBounty {
             keccak256(
                 abi.encode(
                     "alongside::invoker::bounty",
-                    abi.encode(version),
-                    abi.encode(chainId),
                     keccak256(abi.encode(bounty))
                 )
             );

--- a/contracts/src/scripts/Config.sol
+++ b/contracts/src/scripts/Config.sol
@@ -6,7 +6,6 @@ import {TokenInfo} from "src/Common.sol";
 // MAINNET CONFIGS
 string constant NAME = "Alongside Crypto Market Index";
 string constant SYMBOL = "AMKT";
-uint256 constant BOUNTY_VERSION = 0;
 
 // timelock is measured in seconds
 uint256 constant CANCELLATION_PERIOD = 4 days;

--- a/contracts/src/scripts/CoreDeploy.s.sol
+++ b/contracts/src/scripts/CoreDeploy.s.sol
@@ -11,7 +11,7 @@ import {AlongsideGovernor} from "src/Governor.sol";
 import {Quoter} from "periphery/Quoter.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
-import {AMKT_PROXY, MULTISIG, FEE_RECEIPIENT, PROXY_ADMIN, BOUNTY_VERSION, NAME, SYMBOL, CANCELLATION_PERIOD} from "./Config.sol";
+import {AMKT_PROXY, MULTISIG, FEE_RECEIPIENT, PROXY_ADMIN, NAME, SYMBOL, CANCELLATION_PERIOD} from "./Config.sol";
 import {IIndexToken} from "src/interfaces/IIndexToken.sol";
 
 contract CoreDeployScript is Script {
@@ -144,9 +144,7 @@ contract CoreDeployScript is Script {
 
         InvokeableBounty invokeableBounty = new InvokeableBounty({
             _vault: _vault,
-            _activeBounty: address(activeBounty),
-            _version: BOUNTY_VERSION,
-            _chainId: 1
+            _activeBounty: address(activeBounty)
         });
 
         return (invokeableBounty, activeBounty);

--- a/contracts/test/core/State.t.sol
+++ b/contracts/test/core/State.t.sol
@@ -48,12 +48,7 @@ contract StatefulTest is BaseTest, IRebalancer {
 
         quoter = new Quoter(address(vault));
 
-        bounty = new InvokeableBounty(
-            address(vault),
-            address(activeBounty),
-            0,
-            1
-        );
+        bounty = new InvokeableBounty(address(vault), address(activeBounty));
 
         vault.setIssuance(address(issuance));
         vault.setRebalancer(address(bounty));

--- a/contracts/test/symbolic/SymbolicState.t.sol
+++ b/contracts/test/symbolic/SymbolicState.t.sol
@@ -51,12 +51,7 @@ contract SymbolicStatefulTest is SymTest, BaseTest {
 
         quoter = new Quoter(address(vault));
 
-        bounty = new InvokeableBounty(
-            address(vault),
-            address(activeBounty),
-            0,
-            1
-        );
+        bounty = new InvokeableBounty(address(vault), address(activeBounty));
 
         vault.setIssuance(address(issuance));
         vault.setRebalancer(address(bounty));

--- a/contracts/test/upgrade/UpgradedState.t.sol
+++ b/contracts/test/upgrade/UpgradedState.t.sol
@@ -133,8 +133,6 @@ contract UpgradedStateTest is UpgradedTest {
             address(invokeableBounty.activeBounty()),
             address(activeBounty)
         );
-        assertEq(invokeableBounty.version(), 0);
-        assertEq(invokeableBounty.chainId(), 1);
         assertEq(activeBounty.authority(), MULTISIG);
 
         assertEq(address(timelockInvokeableBounty.indexToken()), address(AMKT));
@@ -143,8 +141,6 @@ contract UpgradedStateTest is UpgradedTest {
             address(timelockInvokeableBounty.activeBounty()),
             address(timelockActiveBounty)
         );
-        assertEq(timelockInvokeableBounty.version(), 0);
-        assertEq(timelockInvokeableBounty.chainId(), 1);
         assertEq(timelockActiveBounty.authority(), address(timelockController));
     }
 


### PR DESCRIPTION
`chainId` and `version` are unneeded, as `ActiveBounty` already should serve as the authority for what a valid Bounty is, regardless of chain or version. 