### PR TITLE
audit-fix: Remove timelock bounties

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Alongside Crypto Market Index (AMKT) is a fully backed market index, providing exposure to a market-cap weighted basket of assets, to be rebalanced quarterly.
 
-The next iteration of AMKT moves custody on-chain, relying on `Vault` to custody underlying assets, and on token governance to submit accurate `Bounty` for the next set of underlying assets to rebalance.
+The next iteration of AMKT moves custody on-chain, relying on `Vault` to custody underlying assets, and on governance to submit accurate `Bounty` for the next set of underlying assets to rebalance.
 
 ---
 
@@ -38,7 +38,7 @@ The core system aims to be modular and minimal for maximal safety and extensibil
 
 ### Governance
 
-Governance is responsible for facilitating rebalances, configuring the Vault, and upgrading AMKT. Users can participate in governance with AMKT via [Tally](link-to-tally). Every governance action is subject to a minimum delay of 4 days, enforced by the `TimelockController`.
+Governance is responsible for facilitating rebalances, configuring the Vault, and upgrading AMKT. Users can participate in governance with AMKT via [Tally](link-to-tally). Every governance action besides rebalances is subject to a minimum delay of 4 days, enforced by the `TimelockController`.
 
 To prevent against a malicious token Governance takeover, the Governance Multisig is the only entity authorized to cancel and execute transactions scheduled in `TimelockController`.
 

--- a/contracts/src/scripts/CoreDeploy.s.sol
+++ b/contracts/src/scripts/CoreDeploy.s.sol
@@ -23,8 +23,6 @@ contract CoreDeployScript is Script {
         AlongsideGovernor governor;
         TimelockController timelockController;
         address newTokenImplementation;
-        InvokeableBounty timelockInvokeableBounty;
-        ActiveBounty timelockActiveBounty;
         Quoter quoter;
     }
 
@@ -86,15 +84,6 @@ contract CoreDeployScript is Script {
         IndexToken newTokenImplementation = new IndexToken();
         newTokenImplementation.initialize(address(1));
         deployed.newTokenImplementation = address(newTokenImplementation);
-
-        // Deploy another set of bounty contracts to transfer to timelock controller, since bounty contracts are immutable.
-        (
-            deployed.timelockInvokeableBounty,
-            deployed.timelockActiveBounty
-        ) = deployBounty(
-            address(deployed.vault),
-            address(deployed.timelockController)
-        );
 
         vm.stopBroadcast();
         return deployed;

--- a/contracts/test/core/scripts/CoreDeploy.t.sol
+++ b/contracts/test/core/scripts/CoreDeploy.t.sol
@@ -23,8 +23,6 @@ contract CoreDeployTest is Test {
     AlongsideGovernor governor;
     TimelockController timelockController;
     address newTokenImplementation;
-    InvokeableBounty timelockInvokeableBounty;
-    ActiveBounty timelockActiveBounty;
 
     function setUp() public virtual {
         forkMainnet();
@@ -50,8 +48,6 @@ contract CoreDeployTest is Test {
         governor = deployed.governor;
         timelockController = deployed.timelockController;
         newTokenImplementation = deployed.newTokenImplementation;
-        timelockInvokeableBounty = deployed.timelockInvokeableBounty;
-        timelockActiveBounty = deployed.timelockActiveBounty;
     }
 
     function testGovernanceConfig() public {

--- a/contracts/test/upgrade/MigrationChecklist.t.sol
+++ b/contracts/test/upgrade/MigrationChecklist.t.sol
@@ -70,8 +70,6 @@ contract MigrationChecklistTest is UpgradedTest {
         assertEq(address(governor), address(payable(address(1))));
         assertEq(address(timelockController), address(payable(address(1))));
         assertEq(newTokenImplementation, address(1));
-        assertEq(address(timelockActiveBounty), address(1));
-        assertEq(address(timelockInvokeableBounty), address(1));
     }
 
     // WARNING: This test should fail until `tokens` in InitialBountyHelper is finalized.

--- a/contracts/test/upgrade/UpgradedBounty.t.sol
+++ b/contracts/test/upgrade/UpgradedBounty.t.sol
@@ -33,17 +33,17 @@ contract UpgradedBountyTest is UpgradedTest {
         // generate a valid bounty
         Bounty memory bounty = _generateValidBounty(numTokensToAdd, rand);
         TokenInfo[] memory proposedUnits = bounty.infos;
-        bytes32 _hash = timelockInvokeableBounty.hashBounty(bounty);
+        bytes32 _hash = invokeableBounty.hashBounty(bounty);
 
         // set bounty by anyone except timelock should fail
         vm.startPrank(address(3));
         vm.expectRevert(IActiveBounty.ActiveBountyAuth.selector);
-        timelockActiveBounty.setHash(_hash);
+        activeBounty.setHash(_hash);
         vm.stopPrank();
 
         // set bounty by timelock should succeed
-        vm.prank(address(timelockController));
-        timelockActiveBounty.setHash(_hash);
+        vm.prank(address(MULTISIG));
+        activeBounty.setHash(_hash);
         _satisfyFulfillerBalances(address(this), bounty);
 
         // store balances for old and new tokens for vault and fulfiller (this contract) before fulfilling
@@ -75,11 +75,11 @@ contract UpgradedBountyTest is UpgradedTest {
         // fulfill bounty by anyone except fulfiller should fail
         vm.startPrank(address(4));
         vm.expectRevert(IInvokeableBounty.BountyInvalidFulfiller.selector);
-        timelockInvokeableBounty.fulfillBounty(bounty, false);
+        invokeableBounty.fulfillBounty(bounty, false);
         vm.stopPrank();
 
         // fulfill bounty by fulfiller should succeed
-        timelockInvokeableBounty.fulfillBounty(bounty, false);
+        invokeableBounty.fulfillBounty(bounty, false);
         return (
             oldUnits,
             proposedUnits,
@@ -208,7 +208,7 @@ contract UpgradedBountyTest is UpgradedTest {
                 continue;
             }
             IERC20(ins[i].token).approve(
-                address(timelockInvokeableBounty),
+                address(invokeableBounty),
                 type(uint256).max
             );
             dealer.dealToken(ins[i].token, fulfiller, ins[i].units); // only deal exactly the units needed

--- a/contracts/test/upgrade/UpgradedGovernance.t.sol
+++ b/contracts/test/upgrade/UpgradedGovernance.t.sol
@@ -41,19 +41,9 @@ contract UpgradedGovernanceTest is UpgradedTest {
         return proposal;
     }
 
-    function testRebalance() public {
-        Proposal memory proposal = createSingleItemProposal(
-            address(InvokeableBounty(vault.rebalancer()).activeBounty()),
-            0,
-            abi.encodeWithSignature("setHash(bytes32)", keccak256("hash")),
-            "Test set hash"
-        );
-        makeProposalPass(proposal);
-        assertEq(
-            IActiveBounty(InvokeableBounty(vault.rebalancer()).activeBounty())
-                .activeBounty(),
-            keccak256("hash")
-        );
+    function testMultisigHasBountyAuthority() public {
+        vm.prank(MULTISIG);
+        activeBounty.setHash(keccak256("hash"));
     }
 
     function testAcceptVaultOwnership() public {

--- a/contracts/test/upgrade/UpgradedState.t.sol
+++ b/contracts/test/upgrade/UpgradedState.t.sol
@@ -116,7 +116,7 @@ contract UpgradedStateTest is UpgradedTest {
     function testVaultState() public {
         assertEq(vault.underlyingLength(), 15);
         assertEq(vault.issuance(), address(issuance));
-        assertEq(vault.rebalancer(), address(timelockInvokeableBounty));
+        assertEq(vault.rebalancer(), address(invokeableBounty));
         assertEq(vault.feeRecipient(), FEE_RECEIPIENT);
         assertEq(vault.emergencyResponder(), MULTISIG);
         assertEq(vault.emergency(), false);
@@ -136,16 +136,6 @@ contract UpgradedStateTest is UpgradedTest {
         assertEq(invokeableBounty.version(), 0);
         assertEq(invokeableBounty.chainId(), 1);
         assertEq(activeBounty.authority(), MULTISIG);
-
-        assertEq(address(timelockInvokeableBounty.indexToken()), address(AMKT));
-        assertEq(address(timelockInvokeableBounty.vault()), address(vault));
-        assertEq(
-            address(timelockInvokeableBounty.activeBounty()),
-            address(timelockActiveBounty)
-        );
-        assertEq(timelockInvokeableBounty.version(), 0);
-        assertEq(timelockInvokeableBounty.chainId(), 1);
-        assertEq(timelockActiveBounty.authority(), address(timelockController));
     }
 
     function testTokens() public {

--- a/contracts/test/upgrade/helpers/UpgradePreparation.t.sol
+++ b/contracts/test/upgrade/helpers/UpgradePreparation.t.sol
@@ -28,8 +28,6 @@ contract UpgradePreparationTest is GnosisTest {
     AlongsideGovernor governor;
     TimelockController timelockController;
     address newTokenImplementation;
-    InvokeableBounty timelockInvokeableBounty;
-    ActiveBounty timelockActiveBounty;
     Quoter quoter;
     bytes batchExecutionData;
 
@@ -74,8 +72,6 @@ contract UpgradePreparationTest is GnosisTest {
         governor = deployed.governor;
         timelockController = deployed.timelockController;
         newTokenImplementation = deployed.newTokenImplementation;
-        timelockInvokeableBounty = deployed.timelockInvokeableBounty;
-        timelockActiveBounty = deployed.timelockActiveBounty;
         quoter = deployed.quoter;
         // The below template can be used when the addresses are known.
         // vault = Vault(address(0));
@@ -85,8 +81,6 @@ contract UpgradePreparationTest is GnosisTest {
         // governor = AlongsideGovernor(payable(address(0)));
         // timelockController = TimelockController(payable(address(0)));
         // newTokenImplementation = address(0);
-        // timelockActiveBounty = ActiveBounty(address(0));
-        // timelockInvokeableBounty = InvokeableBounty(address(0));
         // quoter = Quoter(address(0));
     }
 
@@ -179,17 +173,8 @@ contract UpgradePreparationTest is GnosisTest {
             )
         });
 
-        // Set rebalancer to timeblock bounty
-        batch[20] = GnosisTransaction({
-            to: address(vault),
-            data: abi.encodeWithSelector(
-                bytes4(keccak256("setRebalancer(address)")),
-                timelockInvokeableBounty
-            )
-        });
-
         // Transfer vault ownership to timelock
-        batch[21] = GnosisTransaction({
+        batch[20] = GnosisTransaction({
             to: address(vault),
             data: abi.encodeWithSelector(
                 bytes4(keccak256("transferOwnership(address)")),
@@ -198,7 +183,7 @@ contract UpgradePreparationTest is GnosisTest {
         });
 
         // Transfer proxyAdmin ownership to timelock
-        batch[22] = GnosisTransaction({
+        batch[21] = GnosisTransaction({
             to: PROXY_ADMIN,
             data: abi.encodeWithSelector(
                 bytes4(keccak256("transferOwnership(address)")),


### PR DESCRIPTION
To prevent against potential rebalance front running, bounties are no longer timelocked. 