### PR TITLE
astETH

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 libs = ["lib"]
 [fuzz]
 # The number of fuzz runs for fuzz tests
-runs = 1024
+runs = 10240
 [invariant]
 runs = 5
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 libs = ["lib"]
 [fuzz]
 # The number of fuzz runs for fuzz tests
-runs = 5
+runs = 1024
 [invariant]
 runs = 5
 

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity =0.8.18;
+
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -73,10 +73,10 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
     function withdraw(
         uint256 amountToBurn
     ) external reentrancyGuard returns (uint256) {
-        uint totalstETH = stETH.balanceOf(address(this));
+        uint totalStETH = stETH.balanceOf(address(this));
         uint amountToWithdraw = amountToBurn;
-        if (totalstETH < totalSupply()) {
-            amountToWithdraw = (amountToBurn * totalstETH) / totalSupply();
+        if (totalStETH < totalSupply()) {
+            amountToWithdraw = (amountToBurn * totalStETH) / totalSupply();
         }
         _burn(msg.sender, amountToBurn);
         stETH.safeTransfer(msg.sender, amountToWithdraw);

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -70,7 +70,9 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
 
     /// @notice Burn astETH to receive stETH
     /// @param  amountToBurn astETH amount to burn
-    function withdraw(uint256 amountToBurn) external returns (uint256) {
+    function withdraw(
+        uint256 amountToBurn
+    ) external reentrancyGuard returns (uint256) {
         uint totalstETH = stETH.balanceOf(address(this));
         uint amountToWithdraw = amountToBurn;
         if (totalstETH < totalSupply()) {
@@ -84,7 +86,7 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
     ///////////////////////// ADMIN /////////////////////////
 
     /// @notice Transfers excess stETH in the contract to the fee recipient
-    function collectFee() external {
+    function collectFee() external reentrancyGuard {
         uint256 stETHBalance = stETH.balanceOf(address(this));
         uint256 feeToCollect = stETHBalance - totalSupply();
         stETH.safeTransfer(feeRecipient, feeToCollect);

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -5,31 +5,22 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 interface IStETH is IERC20 {
     function submit(address _referral) external payable returns (uint256);
 }
 
 interface IAstETH {
-    error Reentrant();
     event FeeRecipientSet(address feeRecipient);
     event FeeCollected(address feeRecipient, uint256 feeCollected);
 }
 
-contract AstETH is IAstETH, ERC20, Ownable2Step {
+contract AstETH is IAstETH, ERC20, Ownable2Step, ReentrancyGuard {
     using SafeERC20 for IStETH;
 
     IStETH public immutable stETH;
     address public feeRecipient;
-
-    uint256 public reentrancyLock = 1;
-
-    modifier reentrancyGuard() {
-        if (reentrancyLock > 1) revert Reentrant();
-        reentrancyLock = 2;
-        _;
-        reentrancyLock = 1;
-    }
 
     constructor(
         IStETH _stETH,
@@ -45,21 +36,18 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
 
     /// @notice Deposit stETH to receive astETH
     /// @param  amountToMint stETH amount to deposit
+    /// @dev Always mints 1 astETH for depositing 1 stETH
     function deposit(
         uint256 amountToMint
-    ) external reentrancyGuard returns (uint256) {
+    ) external nonReentrant returns (uint256) {
         stETH.safeTransferFrom(msg.sender, address(this), amountToMint);
         _mint(msg.sender, amountToMint);
         return amountToMint;
     }
 
     /// @notice Wraps ETH to stETH before depositing stETH to receive astETH
-    function wrapAndDeposit()
-        external
-        payable
-        reentrancyGuard
-        returns (uint256)
-    {
+    /// @dev Always mints 1 astETH for depositing 1 stETH
+    function wrapAndDeposit() external payable nonReentrant returns (uint256) {
         uint256 balanceBefore = stETH.balanceOf(address(this));
         stETH.submit{value: msg.value}(address(0));
         uint256 balanceAfter = stETH.balanceOf(address(this));
@@ -70,9 +58,11 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
 
     /// @notice Burn astETH to receive stETH
     /// @param  amountToBurn astETH amount to burn
+    /// @dev Withdraws 1 stETH for burning 1 astETH
+    /// @dev To protect against stETH rebasing down, amountToWithdraw is prorated if total supply exceeds stETH balance
     function withdraw(
         uint256 amountToBurn
-    ) external reentrancyGuard returns (uint256) {
+    ) external nonReentrant returns (uint256) {
         uint totalStETH = stETH.balanceOf(address(this));
         uint amountToWithdraw = amountToBurn;
         if (totalStETH < totalSupply()) {
@@ -86,7 +76,7 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
     ///////////////////////// ADMIN /////////////////////////
 
     /// @notice Transfers excess stETH in the contract to the fee recipient
-    function collectFee() external reentrancyGuard {
+    function collectFee() external nonReentrant {
         uint256 stETHBalance = stETH.balanceOf(address(this));
         uint256 feeToCollect = stETHBalance - totalSupply();
         stETH.safeTransfer(feeRecipient, feeToCollect);

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -45,7 +45,9 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
 
     /// @notice Deposit stETH to receive astETH
     /// @param  amountToMint stETH amount to deposit
-    function deposit(uint256 amountToMint) external returns (uint256) {
+    function deposit(
+        uint256 amountToMint
+    ) external reentrancyGuard returns (uint256) {
         stETH.safeTransferFrom(msg.sender, address(this), amountToMint);
         _mint(msg.sender, amountToMint);
         return amountToMint;

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -8,6 +8,7 @@ interface IStETH is IERC20 {
 }
 
 interface IAstETH {
+    error WrapAndDepositMismatch();
     event FeeRecipientSet(address feeRecipient);
     event FeeCollected(address feeRecipient, uint256 feeCollected);
 }
@@ -41,11 +42,11 @@ contract AstETH is IAstETH, ERC20, Ownable2Step {
     /// @notice Wraps ETH to stETH before depositing stETH to receive astETH
     function wrapAndDeposit() external payable returns (uint256) {
         uint256 balanceBefore = stETH.balanceOf(address(this));
-        uint256 shares = stETH.submit{value: msg.value}(address(0));
+        stETH.submit{value: msg.value}(address(0));
         uint256 balanceAfter = stETH.balanceOf(address(this));
-        require(balanceAfter - balanceBefore == shares);
-        _mint(msg.sender, shares);
-        return shares;
+        uint256 amountToMint = balanceAfter - balanceBefore;
+        _mint(msg.sender, amountToMint);
+        return amountToMint;
     }
 
     /// @notice Burn astETH to receive stETH

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -8,7 +8,6 @@ interface IStETH is IERC20 {
 }
 
 interface IAstETH {
-    error WrapAndDepositMismatch();
     event FeeRecipientSet(address feeRecipient);
     event FeeCollected(address feeRecipient, uint256 feeCollected);
 }

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -22,21 +22,21 @@ contract astETH is ERC20, Ownable2Step {
     ///////////////////////// PERMISSIONLESS /////////////////////////
 
     /// @notice Deposit stETH to receive astETH
-    /// @param  amount stETH amount to deposit
-    function deposit(uint256 amount) external {
-        stETH.safeTransferFrom(msg.sender, address(this), amount);
-        _mint(msg.sender, amount);
+    /// @param  amountToMint stETH amount to deposit
+    function deposit(uint256 amountToMint) external {
+        stETH.safeTransferFrom(msg.sender, address(this), amountToMint);
+        _mint(msg.sender, amountToMint);
     }
 
     /// @notice Burn astETH to receive stETH
-    /// @param  sharesToBurn astETH amount to burn
-    function withdraw(uint256 sharesToBurn) external {
+    /// @param  amountToBurn astETH amount to burn
+    function withdraw(uint256 amountToBurn) external {
         uint totalstETH = IERC20(stETH).balanceOf(address(this));
-        uint amountToWithdraw = sharesToBurn;
+        uint amountToWithdraw = amountToBurn;
         if (totalstETH < totalSupply()) {
-            amountToWithdraw = (sharesToBurn * totalstETH) / totalSupply();
+            amountToWithdraw = (amountToBurn * totalstETH) / totalSupply();
         }
-        _burn(msg.sender, sharesToBurn);
+        _burn(msg.sender, amountToBurn);
         stETH.safeTransfer(msg.sender, amountToWithdraw);
     }
 

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -1,0 +1,34 @@
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract astETH is ERC20 {
+    using SafeERC20 for IERC20;
+
+    address public immutable stETH;
+    address public immutable feeRecipient;
+
+    constructor(
+        address _stETH,
+        address _feeRecipient
+    ) ERC20("Alongside stETH", "astETH") {
+        stETH = _stETH;
+        feeRecipient = _feeRecipient;
+    }
+
+    function deposit(uint256 amount) external {
+        IERC20(stETH).safeTransferFrom(msg.sender, address(this), amount);
+        _mint(msg.sender, amount);
+    }
+
+    function withdraw(uint256 amount) external {
+        _burn(msg.sender, amount);
+        IERC20(stETH).safeTransfer(msg.sender, amount);
+    }
+
+    function collectFee() external {
+        uint256 feeToCollect = IERC20(stETH).balanceOf(address(this)) -
+            totalSupply();
+        IERC20(stETH).safeTransfer(feeRecipient, feeToCollect);
+    }
+}

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -15,8 +15,8 @@ contract astETH is ERC20, Ownable2Step {
         address _feeRecipient
     ) ERC20("Alongside stETH", "astETH") {
         stETH = _stETH;
-        _transferOwnership(_owner);
         feeRecipient = _feeRecipient;
+        _transferOwnership(_owner);
     }
 
     ///////////////////////// PERMISSIONLESS /////////////////////////
@@ -35,7 +35,7 @@ contract astETH is ERC20, Ownable2Step {
     function collectFee() external {
         uint256 stETHBalance = stETH.balanceOf(address(this));
         uint256 feeToCollect = stETHBalance - totalSupply();
-        stETH.safeTransfer(owner(), feeToCollect);
+        stETH.safeTransfer(feeRecipient, feeToCollect);
         _invariantCheck();
     }
 

--- a/contracts/periphery/astETH.sol
+++ b/contracts/periphery/astETH.sol
@@ -37,7 +37,7 @@ contract astETH is ERC20, Ownable2Step {
             amountToWithdraw = (sharesToBurn * totalstETH) / totalSupply();
         }
         _burn(msg.sender, sharesToBurn);
-        IERC20(stETH).safeTransfer(msg.sender, amountToWithdraw);
+        stETH.safeTransfer(msg.sender, amountToWithdraw);
     }
 
     /// @notice Transfers excess stETH in the contract to the fee recipient

--- a/contracts/test/periphery/ForkAstETH.t.sol
+++ b/contracts/test/periphery/ForkAstETH.t.sol
@@ -28,5 +28,6 @@ contract AstForkETHTest is BaseTest {
         vm.deal(address(this), amount);
         token.wrapAndDeposit{value: amount}();
         assertGt(amount, token.balanceOf(address(this)));
+        assertLt(amount, token.balanceOf(address(this)) + 3);
     }
 }

--- a/contracts/test/periphery/ForkAstETH.t.sol
+++ b/contracts/test/periphery/ForkAstETH.t.sol
@@ -2,8 +2,6 @@ import {AstETH, IStETH} from "periphery/AstETH.sol";
 import {BaseTest} from "test/utils/BaseTest.t.sol";
 import {MockMintableToken} from "test/utils/MockMintableToken.sol";
 
-// 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
-
 contract AstForkETHTest is BaseTest {
     AstETH token;
     IStETH stETH;

--- a/contracts/test/periphery/ForkAstETH.t.sol
+++ b/contracts/test/periphery/ForkAstETH.t.sol
@@ -1,0 +1,32 @@
+import {AstETH, IStETH} from "periphery/AstETH.sol";
+import {BaseTest} from "test/utils/BaseTest.t.sol";
+import {MockMintableToken} from "test/utils/MockMintableToken.sol";
+
+// 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
+
+contract AstForkETHTest is BaseTest {
+    AstETH token;
+    IStETH stETH;
+
+    function setUp() public {
+        vm.createSelectFork(
+            "https://mainnet.infura.io/v3/2c9945ed9e3c48bd8a3c7166ddd45057",
+            18608317
+        );
+        stETH = IStETH(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
+        token = new AstETH(
+            IStETH(address(stETH)),
+            address(this),
+            address(this)
+        );
+    }
+
+    function testWrapAndDeposit(uint256 amount) public {
+        uint256 STAKE_LIMIT = 1.5e23;
+        amount = bound(amount, 0, STAKE_LIMIT); // cannot deposit more than stake limit
+        vm.assume(amount != 0); // cannot deposit 0
+        vm.deal(address(this), amount);
+        token.wrapAndDeposit{value: amount}();
+        assertGt(amount, token.balanceOf(address(this)));
+    }
+}

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -1,0 +1,39 @@
+import {astETH} from "periphery/astETH.sol";
+import {BaseTest} from "test/utils/BaseTest.t.sol";
+import {MockMintableToken} from "test/utils/MockMintableToken.sol";
+
+// 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
+
+contract astETHTest is BaseTest {
+    astETH token;
+    MockMintableToken sourceToken;
+
+    function setUp() public {
+        sourceToken = new MockMintableToken("stETH", "stETH", 18, 100e18);
+        token = new astETH(address(sourceToken), address(this));
+    }
+
+    function testDeposit() public {
+        uint256 amount = 100e18;
+        sourceToken.approve(address(token), amount);
+        token.deposit(amount);
+        assertEq(token.balanceOf(address(this)), amount);
+    }
+
+    function testWithdraw() public {
+        uint256 amount = 100e18;
+        sourceToken.approve(address(token), amount);
+        token.deposit(amount);
+        token.withdraw(amount);
+        assertEq(token.balanceOf(address(this)), 0);
+    }
+
+    function testCollectFee() public {
+        uint256 amount = 100e18;
+        sourceToken.approve(address(token), amount);
+        token.deposit(amount);
+        deal(address(sourceToken), address(token), 101e18);
+        token.collectFee();
+        assertEq(sourceToken.balanceOf(address(this)), 1e18);
+    }
+}

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -1,6 +1,7 @@
 import {AstETH, IStETH} from "periphery/AstETH.sol";
 import {BaseTest} from "test/utils/BaseTest.t.sol";
 import {MockMintableToken} from "test/utils/MockMintableToken.sol";
+import {console2} from "forge-std/console2.sol";
 
 contract AstETHTest is BaseTest {
     AstETH token;
@@ -16,12 +17,12 @@ contract AstETHTest is BaseTest {
     }
 
     function testDeposit(uint256 amount) public {
-        _mintStETHAndDeposit(amount);
+        _mintStETHAndDeposit(amount, address(this));
         assertEq(token.balanceOf(address(this)), amount);
     }
 
     function testWithdraw(uint256 amount) public {
-        _mintStETHAndDeposit(amount);
+        _mintStETHAndDeposit(amount, address(this));
         token.withdraw(amount);
         assertEq(token.balanceOf(address(this)), 0);
     }
@@ -29,39 +30,106 @@ contract AstETHTest is BaseTest {
     function testCollectFee(uint256 supply, uint256 surplus) public {
         supply = bound(supply, 0, type(uint128).max);
         surplus = bound(surplus, 0, type(uint128).max);
-        _mintStETHAndDeposit(supply);
-        deal(address(stETH), address(token), supply + surplus);
+        _mintStETHAndDeposit(supply, address(this));
+        _rebaseUp(surplus);
         token.collectFee();
         assertEq(stETH.balanceOf(address(this)), surplus);
     }
 
-    function testSlashing(
+    function testSlashingWithdrawalProrated(
         uint256 supply,
-        uint256 rebased,
+        uint256 slashed,
         uint256 withdrawAmount
     ) public {
-        supply = bound(supply, 0, type(uint16).max);
-        rebased = bound(rebased, 0, supply);
+        supply = bound(supply, 0, type(uint128).max);
+        slashed = bound(slashed, 0, supply);
         withdrawAmount = bound(withdrawAmount, 0, supply);
         vm.assume(withdrawAmount != 0);
-        vm.assume(rebased != 0);
+        vm.assume(slashed != 0);
 
         // mint supply
-        _mintStETHAndDeposit(supply);
+        _mintStETHAndDeposit(supply, address(this));
 
         // rebased down, amount received should be proportional
-        deal(address(stETH), address(token), supply - rebased);
+        _rebaseDown(slashed);
 
         token.withdraw(withdrawAmount);
         assertEq(
             stETH.balanceOf(address(this)),
-            (withdrawAmount * (supply - rebased)) / supply
+            (withdrawAmount * (supply - slashed)) / supply
         );
     }
 
-    function _mintStETHAndDeposit(uint256 amount) internal {
-        stETH.mint(address(this), amount);
+    // TODO: Fuzz this
+    function testAttackWithKnownSlashing() public {
+        _mintStETHAndDeposit(300e18, address(this));
+        address attacker = address(2);
+        // 1% rebase down is known
+        //take out a flashloan
+        uint256 attackerLoanAmount = 29700e18; // borrows 29700 wstETH, where 1 wstETH = 1 stETH
+        assertEq(stETH.balanceOf(attacker), 0);
+        _mintStETHAndDeposit(29700e18, attacker);
+        assertEq(token.totalSupply(), 30000e18);
+        assertEq(stETH.balanceOf(address(token)), 30000e18);
+        // trigger 1% rebase down
+        _rebaseDown(300e18); // 1 wstETH = ~0.99 stETH
+        assertEq(token.totalSupply(), 30000e18);
+        assertEq(stETH.balanceOf(address(token)), 29700e18);
+        vm.prank(attacker);
+        token.withdraw(29700e18);
+        assertEq(stETH.balanceOf(attacker), 29403e18); // 29403 = 29700 * 0.99
+        uint256 revenue = (stETH.balanceOf(attacker) * 100e18) / 99e18;
+        uint256 profit = revenue - attackerLoanAmount;
+        assertEq(profit, 0);
+    }
+
+    // TODO: What happens if stETH rebases down, but there are still fees yet to be collected?
+    function testAttackWithKnownSlashingLittleProfit() public {
+        _mintStETHAndDeposit(300e18, address(this));
+        address attacker = address(2);
+        // 1% rebase down is known
+        //take out a flashloan
+        uint256 attackerLoanAmount = 29700e18; // borrows 29700 wstETH, where 1 wstETH = 1 stETH
+        assertEq(stETH.balanceOf(attacker), 0);
+        _mintStETHAndDeposit(29700e18, attacker);
+        assertEq(token.totalSupply(), 30000e18);
+        assertEq(stETH.balanceOf(address(token)), 30000e18);
+        // simulate fees
+        _rebaseUp(270e18);
+        // trigger 1% rebase down
+        _rebaseDown(300e18); // 1 wstETH = ~0.99 stETH
+
+        assertEq(token.totalSupply(), 30000e18);
+        assertEq(stETH.balanceOf(address(token)), 29970e18);
+        vm.prank(attacker);
+        token.withdraw(29700e18);
+        // assertEq(stETH.balanceOf(attacker), 29403e18); // 29403 = 29700 * 0.99
+        uint256 revenue = (stETH.balanceOf(attacker) * 100e18) / 99e18;
+        uint256 profit = revenue - attackerLoanAmount;
+        assertEq(profit, 270e18);
+    }
+
+    function _mintStETHAndDeposit(uint256 amount, address user) internal {
+        stETH.mint(user, amount);
+        vm.startPrank(user);
         stETH.approve(address(token), amount);
         token.deposit(amount);
+        vm.stopPrank();
+    }
+
+    function _rebaseUp(uint256 amount) internal {
+        deal(
+            address(stETH),
+            address(token),
+            stETH.balanceOf(address(token)) + amount
+        );
+    }
+
+    function _rebaseDown(uint256 amount) internal {
+        deal(
+            address(stETH),
+            address(token),
+            stETH.balanceOf(address(token)) - amount
+        );
     }
 }

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -1,18 +1,17 @@
-import {astETH} from "periphery/astETH.sol";
+import {AstETH, IStETH} from "periphery/AstETH.sol";
 import {BaseTest} from "test/utils/BaseTest.t.sol";
 import {MockMintableToken} from "test/utils/MockMintableToken.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
 
 contract astETHTest is BaseTest {
-    astETH token;
+    AstETH token;
     MockMintableToken stETH;
 
     function setUp() public {
         stETH = new MockMintableToken("stETH", "stETH", 18, 0);
-        token = new astETH(
-            IERC20(address(stETH)),
+        token = new AstETH(
+            IStETH(address(stETH)),
             address(this),
             address(this)
         );

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -38,12 +38,12 @@ contract astETHTest is BaseTest {
         assertEq(stETH.balanceOf(address(this)), surplus);
     }
 
-    function testRescue(
+    function testEmergency(
         uint256 supply,
         uint256 rebased,
         uint256 withdrawAmount
     ) public {
-        supply = bound(supply, 0, type(uint256).max);
+        supply = bound(supply, 0, type(uint16).max);
         rebased = bound(rebased, 0, supply);
         withdrawAmount = bound(withdrawAmount, 0, supply);
         vm.assume(withdrawAmount != 0);
@@ -65,8 +65,11 @@ contract astETHTest is BaseTest {
             token.withdraw(withdrawAmount);
         }
 
-        token.rescueStETH();
-        assertEq(stETH.balanceOf(address(this)), supply - rebased);
+        token.emergencyWithdraw(withdrawAmount);
+        assertEq(
+            stETH.balanceOf(address(this)),
+            (withdrawAmount * (supply - rebased)) / supply
+        );
     }
 
     function _mintStETHAndDeposit(uint256 amount) internal {

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -2,9 +2,7 @@ import {AstETH, IStETH} from "periphery/AstETH.sol";
 import {BaseTest} from "test/utils/BaseTest.t.sol";
 import {MockMintableToken} from "test/utils/MockMintableToken.sol";
 
-// 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
-
-contract astETHTest is BaseTest {
+contract AstETHTest is BaseTest {
     AstETH token;
     MockMintableToken stETH;
 

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -38,7 +38,7 @@ contract astETHTest is BaseTest {
         assertEq(stETH.balanceOf(address(this)), surplus);
     }
 
-    function testEmergency(
+    function testSlashing(
         uint256 supply,
         uint256 rebased,
         uint256 withdrawAmount
@@ -52,20 +52,10 @@ contract astETHTest is BaseTest {
         // mint supply
         _mintStETHAndDeposit(supply);
 
-        // rebased down, invariant should fail
+        // rebased down, amount received should be proportional
         deal(address(stETH), address(token), supply - rebased);
 
-        if (withdrawAmount > stETH.balanceOf(address(token))) {
-            // unable to transfer enough stETH
-            vm.expectRevert();
-            token.withdraw(withdrawAmount);
-        } else {
-            // even though it has enough to transfer stETH, it should trigger invariant check failure
-            vm.expectRevert("Invariant check failed");
-            token.withdraw(withdrawAmount);
-        }
-
-        token.emergencyWithdraw(withdrawAmount);
+        token.withdraw(withdrawAmount);
         assertEq(
             stETH.balanceOf(address(this)),
             (withdrawAmount * (supply - rebased)) / supply

--- a/contracts/test/periphery/astETH.t.sol
+++ b/contracts/test/periphery/astETH.t.sol
@@ -1,39 +1,77 @@
 import {astETH} from "periphery/astETH.sol";
 import {BaseTest} from "test/utils/BaseTest.t.sol";
 import {MockMintableToken} from "test/utils/MockMintableToken.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 stETH on mainnet
 
 contract astETHTest is BaseTest {
     astETH token;
-    MockMintableToken sourceToken;
+    MockMintableToken stETH;
 
     function setUp() public {
-        sourceToken = new MockMintableToken("stETH", "stETH", 18, 100e18);
-        token = new astETH(address(sourceToken), address(this));
+        stETH = new MockMintableToken("stETH", "stETH", 18, 0);
+        token = new astETH(
+            IERC20(address(stETH)),
+            address(this),
+            address(this)
+        );
     }
 
-    function testDeposit() public {
-        uint256 amount = 100e18;
-        sourceToken.approve(address(token), amount);
-        token.deposit(amount);
+    function testDeposit(uint256 amount) public {
+        _mintStETHAndDeposit(amount);
         assertEq(token.balanceOf(address(this)), amount);
     }
 
-    function testWithdraw() public {
-        uint256 amount = 100e18;
-        sourceToken.approve(address(token), amount);
-        token.deposit(amount);
+    function testWithdraw(uint256 amount) public {
+        _mintStETHAndDeposit(amount);
         token.withdraw(amount);
         assertEq(token.balanceOf(address(this)), 0);
     }
 
-    function testCollectFee() public {
-        uint256 amount = 100e18;
-        sourceToken.approve(address(token), amount);
-        token.deposit(amount);
-        deal(address(sourceToken), address(token), 101e18);
+    function testCollectFee(uint256 supply, uint256 surplus) public {
+        supply = bound(supply, 0, type(uint128).max);
+        surplus = bound(surplus, 0, type(uint128).max);
+        _mintStETHAndDeposit(supply);
+        deal(address(stETH), address(token), supply + surplus);
         token.collectFee();
-        assertEq(sourceToken.balanceOf(address(this)), 1e18);
+        assertEq(stETH.balanceOf(address(this)), surplus);
+    }
+
+    function testRescue(
+        uint256 supply,
+        uint256 rebased,
+        uint256 withdrawAmount
+    ) public {
+        supply = bound(supply, 0, type(uint256).max);
+        rebased = bound(rebased, 0, supply);
+        withdrawAmount = bound(withdrawAmount, 0, supply);
+        vm.assume(withdrawAmount != 0);
+        vm.assume(rebased != 0);
+
+        // mint supply
+        _mintStETHAndDeposit(supply);
+
+        // rebased down, invariant should fail
+        deal(address(stETH), address(token), supply - rebased);
+
+        if (withdrawAmount > stETH.balanceOf(address(token))) {
+            // unable to transfer enough stETH
+            vm.expectRevert();
+            token.withdraw(withdrawAmount);
+        } else {
+            // even though it has enough to transfer stETH, it should trigger invariant check failure
+            vm.expectRevert("Invariant check failed");
+            token.withdraw(withdrawAmount);
+        }
+
+        token.rescueStETH();
+        assertEq(stETH.balanceOf(address(this)), supply - rebased);
+    }
+
+    function _mintStETHAndDeposit(uint256 amount) internal {
+        stETH.mint(address(this), amount);
+        stETH.approve(address(token), amount);
+        token.deposit(amount);
     }
 }


### PR DESCRIPTION
astETH allows for fee recipient to claim the yield from stETH that gets accrued via rebasing. Including this in AMKT introduces a new way for the fee recipient to earn fees. 

For example, in the next reconstitution, the ETH allocation can be split into 50% wstETH and 50% astETH, while lowering the Vault fee to 0. This increases the number of tokens in the index to 16, and effectively gets fee recipient a 50/50 "yield sharing" with the holders while lowering the Vault fee to 0bps.